### PR TITLE
Disallow ajax search requests when findologic is active

### DIFF
--- a/FinSearchUnified/Subscriber/Frontend.php
+++ b/FinSearchUnified/Subscriber/Frontend.php
@@ -5,6 +5,7 @@ namespace FinSearchUnified\Subscriber;
 use Enlight\Event\SubscriberInterface;
 use Enlight_Controller_ActionEventArgs;
 use Enlight_Event_EventArgs;
+use FinSearchUnified\Helper\StaticHelper;
 use FinSearchUnified\ShopwareProcess;
 
 class Frontend implements SubscriberInterface
@@ -36,7 +37,7 @@ class Frontend implements SubscriberInterface
         return [
             'Shopware_Controllers_Frontend_Search::indexAction::before' => 'beforeSearchIndexAction',
             'Enlight_Controller_Action_PreDispatch'                     => 'onPreDispatch',
-            'Enlight_Controller_Action_PreDispatch_Frontend_AjaxSearch' => 'onPreDispatchAjaxSearch',
+            'Enlight_Controller_Action_Frontend_AjaxSearch_Index' => 'onAjaxSearchIndexAction',
             'Enlight_Controller_Action_PostDispatchSecure_Frontend'     => 'onFrontendPostDispatch',
             'Enlight_Controller_Dispatcher_ControllerPath_Findologic'   => 'onFindologicController',
             'Enlight_Controller_Action_PreDispatch_Frontend_Listing'    => 'onFrontendListingPreDispatch',
@@ -138,12 +139,11 @@ class Frontend implements SubscriberInterface
         return $this->Path().'Controllers/Frontend/Findologic.php';
     }
 
-    public function onPreDispatchAjaxSearch()
+    public function onAjaxSearchIndexAction()
     {
-        $config = Shopware()->Config()->get('ActivateFindologic');
-        if ($config) {
-            echo 'Ajax search inactive';
-            exit();
+        if (!(bool) StaticHelper::useShopSearch()) {
+            Shopware()->Container()->get('front')->Plugins()->ViewRenderer()->setNoRender();
+            return true;
         }
     }
 }

--- a/FinSearchUnified/Subscriber/Frontend.php
+++ b/FinSearchUnified/Subscriber/Frontend.php
@@ -36,6 +36,7 @@ class Frontend implements SubscriberInterface
         return [
             'Shopware_Controllers_Frontend_Search::indexAction::before' => 'beforeSearchIndexAction',
             'Enlight_Controller_Action_PreDispatch'                     => 'onPreDispatch',
+            'Enlight_Controller_Action_PreDispatch_Frontend_AjaxSearch' => 'onPreDispatchAjaxSearch',
             'Enlight_Controller_Action_PostDispatchSecure_Frontend'     => 'onFrontendPostDispatch',
             'Enlight_Controller_Dispatcher_ControllerPath_Findologic'   => 'onFindologicController',
             'Enlight_Controller_Action_PreDispatch_Frontend_Listing'    => 'onFrontendListingPreDispatch',
@@ -135,5 +136,14 @@ class Frontend implements SubscriberInterface
     public function onFindologicController(\Enlight_Event_EventArgs $args)
     {
         return $this->Path().'Controllers/Frontend/Findologic.php';
+    }
+
+    public function onPreDispatchAjaxSearch()
+    {
+        $config = Shopware()->Config()->get('ActivateFindologic');
+        if ($config) {
+            echo 'Ajax search inactive';
+            exit();
+        }
     }
 }


### PR DESCRIPTION
@ihanli made this approach. Already works for one customer but we maybe should consider a better possibilty. Do you have an idea?