### PR TITLE
Revert changes from 07f2613 and add additional check

### DIFF
--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -340,7 +340,7 @@ class FindologicArticleModel
                 }
             }
             if (count($xmlKeywords) > 0) {
-                $this->xmlArticle->setAllKeywords(['' => $xmlKeywords]);
+                $this->xmlArticle->setAllKeywords($xmlKeywords);
             }
         }
     }
@@ -483,14 +483,12 @@ class FindologicArticleModel
             /* @var $configuratorOption \Shopware\Models\Article\Configurator\Option */
             foreach ($variant->getConfiguratorOptions() as $configuratorOption) {
 
-                if (!self::checkIfHasValue($configuratorOption->getName())) {
+                if (!self::checkIfHasValue($configuratorOption->getName())
+                    || !$configuratorOption->getGroup()) {
                     continue;
                 }
 
-                $xmlConfig = new Attribute(
-                    $configuratorOption->getGroup()->getName(),
-                    ['' => $configuratorOption->getName()]
-                );
+                $xmlConfig = new Attribute($configuratorOption->getGroup()->getName(), $configuratorOption->getName());
                 $allAttributes[] = $xmlConfig;
             }
         }

--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -488,7 +488,7 @@ class FindologicArticleModel
                     continue;
                 }
 
-                $xmlConfig = new Attribute($configuratorOption->getGroup()->getName(), $configuratorOption->getName());
+                $xmlConfig = new Attribute($configuratorOption->getGroup()->getName(), [$configuratorOption->getName()]);
                 $allAttributes[] = $xmlConfig;
             }
         }


### PR DESCRIPTION
@ihanli the changes from 07f2613 were not right. The method `setAllKeywords` expects an array of `Keyword` elements. The usergroup is set when creating a `Keyword`-object.

The `Attribute`-Class also expects an array of values (non-associative).

