### PR TITLE
Add productstream data to model

### DIFF
--- a/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchUnified/BusinessLogic/Models/FindologicArticleModel.php
@@ -99,6 +99,9 @@ class FindologicArticleModel
     /* @var Product */
     protected $productStruct;
 
+    /** @var array|false */
+    protected $productStreamArticles;
+
     /**
      * FindologicArticleModel constructor.
      *
@@ -120,6 +123,7 @@ class FindologicArticleModel
         $this->salesFrequency = $salesFrequency;
         $this->allUserGroups = $allUserGroups;
         $this->seoRouter = Shopware()->Container()->get('modules')->sRewriteTable();
+        $this->productStreamArticles = Shopware()->Session()->get(StaticHelper::getProductStreamKey() . 'articles');
 
         $this->setUpStruct();
 
@@ -416,6 +420,14 @@ class FindologicArticleModel
 
         /** @var Category[] $categories */
         $categories = $this->baseArticle->getCategories();
+
+        if (array_key_exists($this->baseArticle->getId(), $this->productStreamArticles)) {
+            $streamCategories = Shopware()->Session()->get(StaticHelper::getProductStreamKey() . 'categories');
+
+            foreach ($this->productStreamArticles[$this->baseArticle->getId()] as $categoryId) {
+                $categories->add($streamCategories[$categoryId]);
+            }
+        }
 
         /** @var Category $category */
         foreach ($categories as $category) {

--- a/FinSearchUnified/Helper/StaticHelper.php
+++ b/FinSearchUnified/Helper/StaticHelper.php
@@ -546,4 +546,9 @@ class StaticHelper {
             !empty(trim(Shopware()->Config()->get('ShopKey'))) &&
             Shopware()->Config()->get('ShopKey') !== 'Findologic Shopkey';
     }
+
+    public static function getProductStreamKey()
+    {
+        return 'findologicProductStreams';
+    }
 }

--- a/FinSearchUnified/ShopwareProcess.php
+++ b/FinSearchUnified/ShopwareProcess.php
@@ -125,7 +125,6 @@ class ShopwareProcess
 
                 /** @var \Shopware\Components\ProductStream\Repository $streamRepositoryService */
                 $streamRepositoryService = Shopware()->Container()->get('shopware_product_stream.repository');
-                $streamCriteria = new Criteria();
 
                 /** @var Category $category */
                 foreach ($results as $category) {
@@ -133,6 +132,8 @@ class ShopwareProcess
                     if (!$category->getActive() || !$category->isChildOf($baseCategory)) {
                         continue;
                     }
+
+                    $streamCriteria = new Criteria();
                     $streamRepositoryService->prepareCriteria($streamCriteria, $category->getStream()->getId());
 
                     $streamArticles = Shopware()->Modules()->Articles()->sGetArticlesByCategory($category->getId(), $streamCriteria);

--- a/FinSearchUnified/Subscriber/Frontend.php
+++ b/FinSearchUnified/Subscriber/Frontend.php
@@ -41,18 +41,7 @@ class Frontend implements SubscriberInterface
             'Enlight_Controller_Action_PostDispatchSecure_Frontend'     => 'onFrontendPostDispatch',
             'Enlight_Controller_Dispatcher_ControllerPath_Findologic'   => 'onFindologicController',
             'Enlight_Controller_Action_PreDispatch_Frontend_Listing'    => 'onFrontendListingPreDispatch',
-            'Enlight_Controller_Action_PreDispatch_Frontend'            => 'onFrontendPreDispatch',
-            //'Shopware\Models\Article\Price::postUpdate'                 => 'onPostPersist',
-            //'Shopware\Models\Article\Price::postPersist'                => 'onPostPersist',
-            'Shopware\Models\Article\Article::postUpdate'               => 'onPostPersist',
-            'Shopware\Models\Article\Article::postPersist'              => 'onPostPersist',
-            //'Shopware\Models\Article\Detail::postUpdate'                => 'onPostPersist',
-            //'Shopware\Models\Article\Detail::postPersist'               => 'onPostPersist',
-            'Shopware\Models\Category\Category::postPersist'            => 'onPostPersist',
-            'Shopware\Models\Category\Category::postUpdate'             => 'onPostPersist',
-            'Shopware\Models\ProductStream\ProductStream::postUpdate'            => 'onPostPersist',
-            'Shopware\Models\ProductStream\ProductStream::postPersist'            => 'onPostPersist',
-            'Shopware\Models\ProductStream\ProductStream::postRemove'            => 'onPostPersist',
+            'Enlight_Controller_Action_PreDispatch_Frontend'            => 'onFrontendPreDispatch'
         ];
     }
 
@@ -131,14 +120,6 @@ class Frontend implements SubscriberInterface
             $view->assign('mainUrl', $mainUrl);
         } catch (\Enlight_Exception $e) {
             //TODO LOGGING
-        }
-    }
-
-    public function onPostPersist() {
-        $cache = Shopware()->Container()->get('cache');
-        if (!$cache->clean(\Zend_Cache::CLEANING_MODE_MATCHING_TAG, ['findologic'])) {
-            $cache->remove(StaticHelper::getProductStreamKey() . 'articles');
-            $cache->remove(StaticHelper::getProductStreamKey() . 'categories');
         }
     }
 

--- a/FinSearchUnified/Subscriber/Frontend.php
+++ b/FinSearchUnified/Subscriber/Frontend.php
@@ -41,7 +41,18 @@ class Frontend implements SubscriberInterface
             'Enlight_Controller_Action_PostDispatchSecure_Frontend'     => 'onFrontendPostDispatch',
             'Enlight_Controller_Dispatcher_ControllerPath_Findologic'   => 'onFindologicController',
             'Enlight_Controller_Action_PreDispatch_Frontend_Listing'    => 'onFrontendListingPreDispatch',
-            'Enlight_Controller_Action_PreDispatch_Frontend'            => 'onFrontendPreDispatch'
+            'Enlight_Controller_Action_PreDispatch_Frontend'            => 'onFrontendPreDispatch',
+            //'Shopware\Models\Article\Price::postUpdate'                 => 'onPostPersist',
+            //'Shopware\Models\Article\Price::postPersist'                => 'onPostPersist',
+            'Shopware\Models\Article\Article::postUpdate'               => 'onPostPersist',
+            'Shopware\Models\Article\Article::postPersist'              => 'onPostPersist',
+            //'Shopware\Models\Article\Detail::postUpdate'                => 'onPostPersist',
+            //'Shopware\Models\Article\Detail::postPersist'               => 'onPostPersist',
+            'Shopware\Models\Category\Category::postPersist'            => 'onPostPersist',
+            'Shopware\Models\Category\Category::postUpdate'             => 'onPostPersist',
+            'Shopware\Models\ProductStream\ProductStream::postUpdate'            => 'onPostPersist',
+            'Shopware\Models\ProductStream\ProductStream::postPersist'            => 'onPostPersist',
+            'Shopware\Models\ProductStream\ProductStream::postRemove'            => 'onPostPersist',
         ];
     }
 
@@ -120,6 +131,14 @@ class Frontend implements SubscriberInterface
             $view->assign('mainUrl', $mainUrl);
         } catch (\Enlight_Exception $e) {
             //TODO LOGGING
+        }
+    }
+
+    public function onPostPersist() {
+        $cache = Shopware()->Container()->get('cache');
+        if (!$cache->clean(\Zend_Cache::CLEANING_MODE_MATCHING_TAG, ['findologic'])) {
+            $cache->remove(StaticHelper::getProductStreamKey() . 'articles');
+            $cache->remove(StaticHelper::getProductStreamKey() . 'categories');
         }
     }
 


### PR DESCRIPTION
This PR depends on #100 

The product stream articles and the product stream categories are put into cache. This has to be done to increase performance while importing.

The cache will be cleared when `Article`, `Detail` and `ProductStream` Models are updated.

@ihanli **WIP**