### PR TITLE
[FIXED] fixed remaining issues from previous pull request

### DIFF
--- a/FinSearchUnified/composer.lock
+++ b/FinSearchUnified/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+      "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "961af80f850519a9f83ee7c0d94b7f24",


### PR DESCRIPTION
In `PluginTest::testArticleExport` put the call of `PluginTest::createTestProduct` in a loop so we can get rid of the duplicate lines.
In `PluginTest::addDataProvider` use the case descriptions as keys for the parameter array. This will give you a more human readable message in case of a failing test. Also remove the case descriptions from the block comment. See the example below for the new data provider:
```
return [
    'both products are active and both are returned' => [[true, true], 2]
]
```
In `PluginTest::addDataProvider` provide a message for the assertion made in the actual test.
Did not use models to truncate data due to concurrency issues and indexes not being reset